### PR TITLE
Add gitleaks scan workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,27 @@
+name: Gitleaks Scan
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          log-level: warn
+          redact: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary
- add a gitleaks workflow that scans every push, pull request, and a weekly cron for leaked secrets
- supply the GitHub token and organization gitleaks license so the action can authenticate, validate the license, and share results

## Background
This site did not have automated secret scanning before. Adding gitleaks provides an early warning if API keys or other credentials are committed. The schedule gives us a regular check even if the repo is quiet, aligning it with the rest of the CivicTechWR portfolio.

## Testing
- not run (workflow only)

@CivicTechWR/organizers please review.
